### PR TITLE
Fail when outside error occurred

### DIFF
--- a/local_test/client_config.rb
+++ b/local_test/client_config.rb
@@ -22,6 +22,7 @@ RRRSpec.configure(:client) do |conf|
       'local_test/success_spec.rb',
       'local_test/fail_spec.rb',
       'local_test/timeout_spec.rb',
+      'local_test/error_outside_examples_spec.rb',
     ]
   end
   conf.setup_command = <<-END

--- a/local_test/client_config.rb
+++ b/local_test/client_config.rb
@@ -22,7 +22,8 @@ RRRSpec.configure(:client) do |conf|
       'local_test/success_spec.rb',
       'local_test/fail_spec.rb',
       'local_test/timeout_spec.rb',
-      'local_test/error_outside_examples_spec.rb',
+      # this file is commented-out because it cause false positive of other tests.
+      # 'local_test/error_outside_examples_spec.rb',
     ]
   end
   conf.setup_command = <<-END

--- a/local_test/error_outside_examples_spec.rb
+++ b/local_test/error_outside_examples_spec.rb
@@ -1,0 +1,8 @@
+describe 'test4' do
+  describe 'outside error' do
+    include_context 'not exist context'
+    it 'cause outside error' do
+      expect(1).to eq(1)
+    end
+  end
+end

--- a/rrrspec-client/lib/rrrspec/client/slave_runner.rb
+++ b/rrrspec-client/lib/rrrspec/client/slave_runner.rb
@@ -12,6 +12,7 @@ module RRRSpec
       TASKQUEUE_ARBITER_TIMEOUT = 20
       TIMEOUT_EXITCODE = 42
       class SoftTimeoutException < Exception; end
+      class OutsideExamplesError < StandardError; end
 
       def initialize(slave, working_dir, taskset_key)
         @slave = slave
@@ -92,7 +93,9 @@ module RRRSpec
       end
 
       class RedisReportingFormatter
-        RSpec::Core::Formatters.register(self, :example_passed, :example_pending, :example_failed)
+        RSpec::Core::Formatters.register(
+          self, :example_passed, :example_pending, :example_failed, :dump_summary
+        )
 
         def initialize(_output)
           self.class.reset
@@ -108,6 +111,14 @@ module RRRSpec
 
         def example_failed(notification)
           self.class.example_failed(notification)
+        end
+
+        def dump_summary(notification)
+          # RSpec skips all examples when error outside examples occurred
+          # So we will raise error and make current taskset failure
+          if notification.errors_outside_of_examples_count.positive?
+            raise OutsideExamplesError
+          end
         end
 
         module ClassMethods


### PR DESCRIPTION
### Problem

rrrspec reports false results when `errors_outside_of_examples` has positive counts; for example, `include_context` is used but no context in it.
In this case, examples in other files are also skipped.

Local test result of https://github.com/misoca/rrrspec/pull/2/commits/09c15723e4150597b6e5b8bc7723198816d32e54  is here.

![2018-01-19 18 07 53](https://user-images.githubusercontent.com/1789266/35143090-bf65232e-fd43-11e7-9d1c-f2256c36be27.png)

### Solution

https://github.com/misoca/rrrspec/pull/2/commits/01481f88442eda2667b3a717095232e830f97812 fix that case by checking `errors_outside_of_examples_count` in report summary.
Local test result of the commit is here.

![2018-01-19 17 59 19](https://user-images.githubusercontent.com/1789266/35143094-c478c186-fd43-11e7-928a-f2d73ebf61b9.png)
