### PR TITLE
rrrspec-web の haml の依存をバージョン 5.0.x にする

### DIFF
--- a/rrrspec-web/rrrspec-web.gemspec
+++ b/rrrspec-web/rrrspec-web.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "bootstrap-sass", ">= 3.2"
   spec.add_dependency "coffee-script", "~> 2.2.0"
   spec.add_dependency "grape", '~> 1.1.0'
-  spec.add_dependency "haml", "~> 4.0.3"
+  spec.add_dependency "haml", "~> 5.0.0"
   spec.add_dependency "kaminari", "~> 0.16.0"
   spec.add_dependency "oj"
   spec.add_dependency "rrrspec-client"


### PR DESCRIPTION
For https://nvd.nist.gov/vuln/detail/CVE-2017-1002201